### PR TITLE
Add a main Makefile to build all firmwares.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ Gemfile.lock
 parts/
 
 bin/
+
+*.elf

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+# Define all target architectures
+#
+# For each target define:
+#
+#  * PREFIX_$(target) variable with the firmware name prefix
+#
+
+
+ARCHIS += iotlab-m3
+PREFIX_iotlab-m3 = m3
+
+ARCHIS += iotlab-a8-m3
+PREFIX_iotlab-a8-m3 = a8
+
+ARCHIS += fox
+PREFIX_fox = fox
+
+ARCHIS += samr21-xpro
+PREFIX_samr21-xpro = samr21
+
+ARCHIS += arduino-mega2560
+PREFIX_arduino-mega2560 = mega
+
+
+include Makefile.in

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,0 +1,45 @@
+# Prerequisite
+
+all: init_submodules
+
+.PHONY: init_submodules
+init_submodules:
+	git submodule update --init --recursive
+
+
+# All targets
+
+AUTOTESTS = $(foreach archi, $(ARCHIS), $(PREFIX_$(archi))_autotest.elf)
+IDLES = $(foreach archi, $(ARCHIS), $(PREFIX_$(archi))_idle.elf)
+
+
+all: $(AUTOTESTS) $(IDLES)
+
+
+# Generate rules to copy firmwares to root
+define copy
+$(1): $(2)
+	cp $$^ $$@
+endef
+
+$(foreach archi, $(ARCHIS), \
+	$(eval $(call copy, $(PREFIX_$(archi))_autotest.elf, \
+	firmwares/autotest/bin/$(archi)/autotest.elf)))
+
+$(foreach archi, $(ARCHIS), \
+	$(eval $(call copy, $(PREFIX_$(archi))_idle.elf, \
+	firmwares/idle/bin/$(archi)/riot-idle.elf)))
+
+
+# Build firmwares
+firmwares/autotest/bin/%/autotest.elf:
+	make -C firmwares/autotest/ BOARD=$*
+firmwares/idle/bin/%/riot-idle.elf:
+	make -C firmwares/idle/ BOARD=$*
+
+
+clean:
+	rm -f *_autotest.elf
+	rm -f *_idle.elf
+	rm -rf firmwares/autotest/bin
+	rm -rf firmwares/idle/bin

--- a/README.md
+++ b/README.md
@@ -24,20 +24,22 @@ To be continued...
 ### Usage
 
 1. Build the firmwares
-<pre>
-$ cd ci-firmwares
-$ for firmware in idle autotest
-do
-cd firmwares/$firmware
-for board in iotlab-m3 samr21-xpro arduino-mega2560 fox
-do
-make BOARD=$board
-done
-cd ../..
-done
-</pre>
-2. Copy the firmware in the **iotlab-gateway** repositoty. The built firmwares are
-   located in **firmwares/autotest/bin/samr21-xpro/autotest.elf** for example.
+```
+$ make all
+git submodule update --init --recursive
+make -C firmwares/autotest/ BOARD=iotlab-m3
+make[1]: Entering directory `/home/harter/work/ci-firmwares/firmwares/autotest'
+...
+make[1]: Leaving directory `/home/harter/work/ci-firmwares/firmwares/idle'
+cp firmwares/idle/bin/arduino-mega2560/riot-idle.elf mega_idle.elf
+
+$ ls *.elf
+a8_autotest.elf   fox_idle.elf     mega_autotest.elf    samr21_idle.elf
+a8_idle.elf       m3_autotest.elf  mega_idle.elf
+fox_autotest.elf  m3_idle.elf      samr21_autotest.elf
+```
+
+2. Copy the firmware in the **iotlab-gateway** repositoty.
    The destination folder is **iotlab-gateway/gateway-code/static**.
 
 


### PR DESCRIPTION
Run 'make' to build all targets and copy them in the base directory with according prefix.
